### PR TITLE
Precipitation feature

### DIFF
--- a/docs/src/active-layer-transport.md
+++ b/docs/src/active-layer-transport.md
@@ -586,7 +586,7 @@ transport_solver(::Type{Val{:RK4}}, box) = runge_kutta_4(typeof(1.0u"m"), box)
 transport_solver(::Type{Val{:forward_euler}}, _) = forward_euler
 
 function precipitation_factor(input::AbstractInput)
-    if input.precipitation_rate === nothing
+    if input.precipitation_time === nothing
         return 1.0
     else
         return 1.0 - exp(input.time.Δt * log(1/2) / input.precipitation_time)

--- a/docs/src/active-layer-transport.md
+++ b/docs/src/active-layer-transport.md
@@ -589,7 +589,7 @@ function precipitation_factor(input::AbstractInput)
     if input.precipitation_rate === nothing
         return 1.0
     else
-        return exp(input.time.Δt * input.precipitation_rate)
+        return 1.0 - exp(input.time.Δt * input.precipitation_rate)
     end
 end
 

--- a/docs/src/active-layer-transport.md
+++ b/docs/src/active-layer-transport.md
@@ -573,7 +573,7 @@ end
 @kwdef struct Input <: AbstractInput
     intertidal_zone::Height = 0.0u"m"
     disintegration_rate::Rate = 50.0u"m/Myr"
-    precipitation_rate::Union{typeof(1.0u"1/Myr"), Nothing} = nothing
+    precipitation_time::Union{typeof(1.0u"Myr"), Nothing} = nothing
     transport_solver = Val{:RK4}
     transport_substeps = :adaptive 
 end
@@ -589,7 +589,7 @@ function precipitation_factor(input::AbstractInput)
     if input.precipitation_rate === nothing
         return 1.0
     else
-        return 1.0 - exp(input.time.Δt * input.precipitation_rate)
+        return 1.0 - exp(input.time.Δt * log(1/2) / input.precipitation_time)
     end
 end
 

--- a/docs/src/active-layer-transport.md
+++ b/docs/src/active-layer-transport.md
@@ -553,7 +553,7 @@ CarboKitten.Components.ActiveLayer
 @compose module ActiveLayer
 @mixin WaterDepth, FaciesBase, SedimentBuffer
 
-export disintegrator, transporter
+export disintegrator, transporter, precipitation_factor
 
 using ..Common
 using CarboKitten.Transport.Advection: transport, advection_coef!, transport_dC!, max_dt
@@ -573,7 +573,7 @@ end
 @kwdef struct Input <: AbstractInput
     intertidal_zone::Height = 0.0u"m"
     disintegration_rate::Rate = 50.0u"m/Myr"
-    precipitation_fraction::Float64 = 1.0
+    precipitation_rate::Union{typeof(1.0u"1/Myr"), Nothing} = nothing
     transport_solver = Val{:RK4}
     transport_substeps = :adaptive 
 end
@@ -584,6 +584,14 @@ courant_max(::Type{Val{:forward_euler}}) = 1.0
 transport_solver(f, _) = f
 transport_solver(::Type{Val{:RK4}}, box) = runge_kutta_4(typeof(1.0u"m"), box)
 transport_solver(::Type{Val{:forward_euler}}, _) = forward_euler
+
+function precipitation_factor(input::AbstractInput)
+    if input.precipitation_rate === nothing
+        return 1.0
+    else
+        return exp(input.time.Δt * input.precipitation_rate)
+    end
+end
 
 function adaptive_transporter(input)
     solver = transport_solver(input.transport_solver, input.box)

--- a/docs/src/model-alcap.md
+++ b/docs/src/model-alcap.md
@@ -171,7 +171,7 @@ function step!(input::Input)
     transport! = ActiveLayer.transporter(input)
     local_water_depth = water_depth(input)
     na = [CartesianIndex()]
-    pf = input.precipitation_fraction
+    pf = precipitation_factor(input)
 
     function (state::State)
         if mod(state.step, input.ca_interval) == 0

--- a/docs/src/model-alcap.md
+++ b/docs/src/model-alcap.md
@@ -152,10 +152,12 @@ function initial_state(input::AbstractInput)
 
     sediment_height = zeros(Height, input.box.grid_size...)
     sediment_buffer = zeros(Float64, input.sediment_buffer_size, n_facies(input), input.box.grid_size...)
+    active_layer = zeros(Amount, n_facies(input), input.box.grid_size...)
 
     state = State(
         step=0, sediment_height=sediment_height,
         sediment_buffer=sediment_buffer,
+        active_layer = active_layer,
         ca=ca_state.ca, ca_priority=ca_state.ca_priority)
 
     InitialSediment.push_initial_sediment!(input, state)
@@ -169,6 +171,7 @@ function step!(input::Input)
     transport! = ActiveLayer.transporter(input)
     local_water_depth = water_depth(input)
     na = [CartesianIndex()]
+    pf = input.precipitation_fraction
 
     function (state::State)
         if mod(state.step, input.ca_interval) == 0
@@ -179,17 +182,20 @@ function step!(input::Input)
         p = produce(state, wd)
         d = disintegrate!(state)
 
-        active_layer = p .+ d
-        transport!(state, active_layer)
+        state.active_layer .+= p
+        state.active_layer .+= d
+        transport!(state)
 
-        push_sediment!(state.sediment_buffer, active_layer ./ input.depositional_resolution .|> NoUnits)
-        state.sediment_height .+= sum(active_layer; dims=1)[1,:,:]
+        deposit = pf .* state.active_layer
+        push_sediment!(state.sediment_buffer, deposit ./ input.depositional_resolution .|> NoUnits)
+        state.active_layer .-= deposit
+        state.sediment_height .+= sum(deposit; dims=1)[1,:,:]
         state.step += 1
 
         return Frame(
             production = p,
             disintegration = d,
-            deposition = active_layer)
+            deposition = deposit)
     end
 end
 

--- a/docs/src/models/without-ca.md
+++ b/docs/src/models/without-ca.md
@@ -28,7 +28,7 @@ function step!(input::Input)
     dt = input.time.Δt
     local_water_depth = water_depth(input)
     na = [CartesianIndex()]
-    pf = input.precipitation_fraction
+    pf = precipitation_factor(input)
 
     function (state::State)
         wd = local_water_depth(state)

--- a/docs/src/models/without-ca.md
+++ b/docs/src/models/without-ca.md
@@ -17,7 +17,8 @@ export Input, Facies
 function initial_state(input::Input)
     sediment_height = zeros(Height, input.box.grid_size...)
     sediment_buffer = zeros(Float64, input.sediment_buffer_size, n_facies(input), input.box.grid_size...)
-    return State(step=0, sediment_height=sediment_height, sediment_buffer=sediment_buffer)
+    active_layer = zeros(Amount, n_facies(input), input.box.grid_size...)
+    return State(step=0, sediment_height=sediment_height, sediment_buffer=sediment_buffer, active_layer=active_layer)
 end
 
 function step!(input::Input)
@@ -27,23 +28,27 @@ function step!(input::Input)
     dt = input.time.Δt
     local_water_depth = water_depth(input)
     na = [CartesianIndex()]
+    pf = input.precipitation_fraction
 
     function (state::State)
         wd = local_water_depth(state)
         p = produce(state, wd)
         d = disintegrate!(state)
 
-        active_layer = p .+ d
-        transport!(state, active_layer)
+        state.active_layer .+= p
+        state.active_layer .+= d
+        transport!(state)
 
-        push_sediment!(state.sediment_buffer, active_layer ./ input.depositional_resolution .|> NoUnits)
-        state.sediment_height .+= sum(active_layer; dims=1)[1,:,:]
+        deposit = pf .* state.active_layer
+        push_sediment!(state.sediment_buffer, deposit ./ input.depositional_resolution .|> NoUnits)
+        state.active_layer .-= deposit
+        state.sediment_height .+= sum(deposit; dims=1)[1,:,:]
         state.step += 1
 
         return Frame(
             production = p,
             disintegration = d,
-            deposition = active_layer)
+            deposition = deposit)
     end
 end
 

--- a/src/Components/ActiveLayer.jl
+++ b/src/Components/ActiveLayer.jl
@@ -35,7 +35,7 @@ transport_solver(::Type{Val{:RK4}}, box) = runge_kutta_4(typeof(1.0u"m"), box)
 transport_solver(::Type{Val{:forward_euler}}, _) = forward_euler
 
 function precipitation_factor(input::AbstractInput)
-    if input.precipitation_rate === nothing
+    if input.precipitation_time === nothing
         return 1.0
     else
         return 1.0 - exp(input.time.Δt * log(1/2) / input.precipitation_time)

--- a/src/Components/ActiveLayer.jl
+++ b/src/Components/ActiveLayer.jl
@@ -38,7 +38,7 @@ function precipitation_factor(input::AbstractInput)
     if input.precipitation_rate === nothing
         return 1.0
     else
-        return exp(input.time.Δt * input.precipitation_rate)
+        return 1.0 - exp(input.time.Δt * input.precipitation_rate)
     end
 end
 

--- a/src/Components/ActiveLayer.jl
+++ b/src/Components/ActiveLayer.jl
@@ -22,7 +22,7 @@ end
 @kwdef struct Input <: AbstractInput
     intertidal_zone::Height = 0.0u"m"
     disintegration_rate::Rate = 50.0u"m/Myr"
-    precipitation_rate::Union{typeof(1.0u"1/Myr"), Nothing} = nothing
+    precipitation_time::Union{typeof(1.0u"Myr"), Nothing} = nothing
     transport_solver = Val{:RK4}
     transport_substeps = :adaptive 
 end
@@ -38,7 +38,7 @@ function precipitation_factor(input::AbstractInput)
     if input.precipitation_rate === nothing
         return 1.0
     else
-        return 1.0 - exp(input.time.Δt * input.precipitation_rate)
+        return 1.0 - exp(input.time.Δt * log(1/2) / input.precipitation_time)
     end
 end
 

--- a/src/Components/ActiveLayer.jl
+++ b/src/Components/ActiveLayer.jl
@@ -15,9 +15,14 @@ using GeometryBasics
     wave_velocity = _ -> (Vec2(0.0u"m/Myr", 0.0u"m/Myr"), Vec2(0.0u"1/Myr", 0.0u"1/Myr"))
 end
 
+@kwdef mutable struct State <: AbstractState
+    active_layer::Array{Amount, 3}
+end
+
 @kwdef struct Input <: AbstractInput
     intertidal_zone::Height = 0.0u"m"
     disintegration_rate::Rate = 50.0u"m/Myr"
+    precipitation_fraction::Float64 = 1.0
     transport_solver = Val{:RK4}
     transport_substeps = :adaptive 
 end
@@ -42,10 +47,11 @@ function adaptive_transporter(input)
     cm = courant_max(input.transport_solver)
     iz = input.intertidal_zone
 
-    return function (state, C::Array{Amount,3})
+    return function (state)
         wd = w(state)
         wd .+= iz
 
+        C = state.active_layer
         for (i, f) in pairs(fs)
             advection_coef!(box, f.diffusion_coefficient, f.wave_velocity, wd, adv, rct)
             m = max_dt(adv, box.phys_scale, cm)
@@ -114,10 +120,11 @@ function transporter(input)
     fs = input.facies
     iz = input.intertidal_zone
 
-    return function (state, C::Array{Amount,3})
+    return function (state)
         wd = w(state)
         wd .+= iz
 
+        C = state.active_layer
         for (i, f) in pairs(fs)
             for j in 1:steps
                 solver(

--- a/src/Models/ALCAP.jl
+++ b/src/Models/ALCAP.jl
@@ -37,7 +37,7 @@ function step!(input::Input)
     transport! = ActiveLayer.transporter(input)
     local_water_depth = water_depth(input)
     na = [CartesianIndex()]
-    pf = input.precipitation_fraction
+    pf = precipitation_factor(input)
 
     function (state::State)
         if mod(state.step, input.ca_interval) == 0

--- a/src/Models/ALCAP.jl
+++ b/src/Models/ALCAP.jl
@@ -18,10 +18,12 @@ function initial_state(input::AbstractInput)
 
     sediment_height = zeros(Height, input.box.grid_size...)
     sediment_buffer = zeros(Float64, input.sediment_buffer_size, n_facies(input), input.box.grid_size...)
+    active_layer = zeros(Amount, n_facies(input), input.box.grid_size...)
 
     state = State(
         step=0, sediment_height=sediment_height,
         sediment_buffer=sediment_buffer,
+        active_layer = active_layer,
         ca=ca_state.ca, ca_priority=ca_state.ca_priority)
 
     InitialSediment.push_initial_sediment!(input, state)
@@ -35,6 +37,7 @@ function step!(input::Input)
     transport! = ActiveLayer.transporter(input)
     local_water_depth = water_depth(input)
     na = [CartesianIndex()]
+    pf = input.precipitation_fraction
 
     function (state::State)
         if mod(state.step, input.ca_interval) == 0
@@ -45,17 +48,20 @@ function step!(input::Input)
         p = produce(state, wd)
         d = disintegrate!(state)
 
-        active_layer = p .+ d
-        transport!(state, active_layer)
+        state.active_layer .+= p
+        state.active_layer .+= d
+        transport!(state)
 
-        push_sediment!(state.sediment_buffer, active_layer ./ input.depositional_resolution .|> NoUnits)
-        state.sediment_height .+= sum(active_layer; dims=1)[1,:,:]
+        deposit = pf .* state.active_layer
+        push_sediment!(state.sediment_buffer, deposit ./ input.depositional_resolution .|> NoUnits)
+        state.active_layer .-= deposit
+        state.sediment_height .+= sum(deposit; dims=1)[1,:,:]
         state.step += 1
 
         return Frame(
             production = p,
             disintegration = d,
-            deposition = active_layer)
+            deposition = deposit)
     end
 end
 

--- a/src/Models/WithoutCA.jl
+++ b/src/Models/WithoutCA.jl
@@ -24,7 +24,7 @@ function step!(input::Input)
     dt = input.time.Δt
     local_water_depth = water_depth(input)
     na = [CartesianIndex()]
-    pf = input.precipitation_fraction
+    pf = precipitation_factor(input)
 
     function (state::State)
         wd = local_water_depth(state)

--- a/src/Models/WithoutCA.jl
+++ b/src/Models/WithoutCA.jl
@@ -13,7 +13,8 @@ export Input, Facies
 function initial_state(input::Input)
     sediment_height = zeros(Height, input.box.grid_size...)
     sediment_buffer = zeros(Float64, input.sediment_buffer_size, n_facies(input), input.box.grid_size...)
-    return State(step=0, sediment_height=sediment_height, sediment_buffer=sediment_buffer)
+    active_layer = zeros(Amount, n_facies(input), input.box.grid_size...)
+    return State(step=0, sediment_height=sediment_height, sediment_buffer=sediment_buffer, active_layer=active_layer)
 end
 
 function step!(input::Input)
@@ -23,23 +24,27 @@ function step!(input::Input)
     dt = input.time.Δt
     local_water_depth = water_depth(input)
     na = [CartesianIndex()]
+    pf = input.precipitation_fraction
 
     function (state::State)
         wd = local_water_depth(state)
         p = produce(state, wd)
         d = disintegrate!(state)
 
-        active_layer = p .+ d
-        transport!(state, active_layer)
+        state.active_layer .+= p
+        state.active_layer .+= d
+        transport!(state)
 
-        push_sediment!(state.sediment_buffer, active_layer ./ input.depositional_resolution .|> NoUnits)
-        state.sediment_height .+= sum(active_layer; dims=1)[1,:,:]
+        deposit = pf .* state.active_layer
+        push_sediment!(state.sediment_buffer, deposit ./ input.depositional_resolution .|> NoUnits)
+        state.active_layer .-= deposit
+        state.sediment_height .+= sum(deposit; dims=1)[1,:,:]
         state.step += 1
 
         return Frame(
             production = p,
             disintegration = d,
-            deposition = active_layer)
+            deposition = deposit)
     end
 end
 


### PR DESCRIPTION
closes #149

- [x] Implements a `precipitation_fraction` that defaults to 1. An active layer is kept in memory and only a fraction of entrained material is precipitated. By setting the default to 1, previous behaviour is retained.
- [x] Checked that ALCAP still runs
- [x] Reparametrize precipitation to physical units (probably half-value time)