### PR TITLE
fix initial topography in tabular sl example

### DIFF
--- a/docs/src/cases/tabular-sea-level.md
+++ b/docs/src/cases/tabular-sea-level.md
@@ -107,7 +107,7 @@ const INPUT = ALCAP.Input(
     box=CarboKitten.Box{Coast}(grid_size=(100, 50), phys_scale=150.0u"m"),
     time=TIME_PROPERTIES,
     ca_interval=1,
-    initial_topography=(x, y) -> -x / 200.0 - 100.0u"m",
+    initial_topography=(x, y) -> -x / 200.0,
     sea_level=sea_level(),
     subsidence_rate=50.0u"m/Myr",
     disintegration_rate=50.0u"m/Myr",

--- a/examples/tabular-sea-level/plot.jl
+++ b/examples/tabular-sea-level/plot.jl
@@ -77,7 +77,7 @@ const INPUT = ALCAP.Input(
     box=CarboKitten.Box{Coast}(grid_size=(100, 50), phys_scale=150.0u"m"),
     time=TIME_PROPERTIES,
     ca_interval=1,
-    initial_topography=(x, y) -> -x / 200.0 - 100.0u"m",
+    initial_topography=(x, y) -> -x / 200.0,
     sea_level=sea_level(),
     subsidence_rate=50.0u"m/Myr",
     disintegration_rate=50.0u"m/Myr",

--- a/examples/tabular-sea-level/run.jl
+++ b/examples/tabular-sea-level/run.jl
@@ -74,7 +74,7 @@ const INPUT = ALCAP.Input(
     box=CarboKitten.Box{Coast}(grid_size=(100, 50), phys_scale=150.0u"m"),
     time=TIME_PROPERTIES,
     ca_interval=1,
-    initial_topography=(x, y) -> -x / 200.0 - 100.0u"m",
+    initial_topography=(x, y) -> -x / 200.0,
     sea_level=sea_level(),
     subsidence_rate=50.0u"m/Myr",
     disintegration_rate=50.0u"m/Myr",


### PR DESCRIPTION
fixes #186 

Turns out the initial topography was very deep (- 100 m), leading to immediate drowning of 2 of the 3 carbonate factories. For some reason the figures in the documentation were not updated to reflect this, meaning figures and code were inconsistent.

I fixed the drowning by adjusting the initial topography, which should fix the issue. I could not tangle due to problems running entangled [see here](https://github.com/entangled/entangled.py/issues/74). @jhidding can you check everything works & plots as expected, and tangle? I'd hate to leave a mess in the repo.