### PR TITLE
fix elevation calculation

### DIFF
--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -42,7 +42,7 @@ const na = [CartesianIndex()]
 
 elevation(h::Header, d::DataSlice) =
     let bl = h.initial_topography[d.slice..., na],
-        sr = h.axes.t[end] * h.subsidence_rate
+        sr = (h.axes.t[end] - h.axes.t[1]) * h.subsidence_rate
 
         bl .+ d.sediment_thickness .- sr
     end

--- a/ext/WheelerDiagram.jl
+++ b/ext/WheelerDiagram.jl
@@ -15,7 +15,7 @@ const na = [CartesianIndex()]
 
 elevation(h::Header, d::DataSlice) =
     let bl = h.initial_topography[d.slice..., na],
-        sr = h.axes.t[end] * h.subsidence_rate
+        sr = (h.axes.t[end] - h.axes.t[1]) * h.subsidence_rate
 
         bl .+ d.sediment_thickness .- sr
     end


### PR DESCRIPTION
Fixes calculation of `elevation` in the `WheelerDiagram` module.

Currently this calculation only depends on the final element of header.axes.t, which leads to wrong calculations when the model is run for non-standard time scales (e.g., offset from 0). This leads to downstream breakage of the water depth calculation and the Wheeler-diagram (see e.g. https://mindthegap-erc.github.io/CarboKitten.jl/dev/cases/tabular-sea-level/).

This commit should fix the calculation.