### PR TITLE
246 CAP model fix

### DIFF
--- a/docs/src/bosscher-1992.md
+++ b/docs/src/bosscher-1992.md
@@ -315,17 +315,20 @@ using CarboKitten
 
 const FACIES = [
     BS92.Facies(
-         maximum_growth_rate=500u"m/Myr"/4,
-         extinction_coefficient=0.8u"m^-1",
-         saturation_intensity=60u"W/m^2"),
+        production=BenthicProduction(
+            maximum_growth_rate=500u"m/Myr"/4,
+            extinction_coefficient=0.8u"m^-1",
+            saturation_intensity=60u"W/m^2")),
     BS92.Facies(
-         maximum_growth_rate=400u"m/Myr"/4,
-         extinction_coefficient=0.1u"m^-1",
-         saturation_intensity=60u"W/m^2"),
+        production=BenthicProduction(
+            maximum_growth_rate=400u"m/Myr"/4,
+            extinction_coefficient=0.1u"m^-1",
+            saturation_intensity=60u"W/m^2")),
     BS92.Facies(
-         maximum_growth_rate=100u"m/Myr"/4,
-         extinction_coefficient=0.005u"m^-1",
-         saturation_intensity=60u"W/m^2")]
+        production=BenthicProduction(
+            maximum_growth_rate=100u"m/Myr"/4,
+            extinction_coefficient=0.005u"m^-1",
+            saturation_intensity=60u"W/m^2"))]
 
 const INPUT = BS92.Input(
     tag = "example model BS92",

--- a/docs/src/bosscher-1992.md
+++ b/docs/src/bosscher-1992.md
@@ -273,9 +273,10 @@ const INPUT = BS92.Input(
     subsidence_rate = 0.0u"m/yr",
     insolation = 400.0u"W/m^2",
     facies = [BS92.Facies(
-      maximum_growth_rate = 0.005u"m/yr",
-      saturation_intensity = 50.0u"W/m^2",
-      extinction_coefficient = 0.05u"m^-1"
+      production=BenthicProduction(
+        maximum_growth_rate = 0.005u"m/yr",
+        saturation_intensity = 50.0u"W/m^2",
+        extinction_coefficient = 0.05u"m^-1")
     )])
 
 function main()

--- a/docs/src/models/ca-with-production.md
+++ b/docs/src/models/ca-with-production.md
@@ -23,23 +23,29 @@ const FACIES = [
 	    CAP.Facies(
         viability_range = (4, 10),
         activation_range = (6, 10),
-        maximum_growth_rate = 500u"m/Myr",
-        extinction_coefficient = 0.8u"m^-1",
-        saturation_intensity = 60u"W/m^2"),
+        production=BenthicProduction(
+            maximum_growth_rate = 500u"m/Myr",
+            extinction_coefficient = 0.8u"m^-1",
+            saturation_intensity = 60u"W/m^2"
+        )),
 
 	    CAP.Facies(
         viability_range = (4, 10),
         activation_range = (6, 10),
-        maximum_growth_rate = 400u"m/Myr",
-        extinction_coefficient = 0.1u"m^-1",
-        saturation_intensity = 60u"W/m^2"),
+        production=BenthicProduction(
+            maximum_growth_rate = 400u"m/Myr",
+            extinction_coefficient = 0.1u"m^-1",
+            saturation_intensity = 60u"W/m^2"
+        )),
 
 	    CAP.Facies(
         viability_range = (4, 10),
         activation_range = (6, 10),
-        maximum_growth_rate = 100u"m/Myr",
-        extinction_coefficient = 0.005u"m^-1",
-        saturation_intensity = 60u"W/m^2")
+        production=BenthicProduction(
+            maximum_growth_rate = 100u"m/Myr",
+            extinction_coefficient = 0.005u"m^-1",
+            saturation_intensity = 60u"W/m^2"
+        ))
 	]
 
 	const INPUT = CAP.Input(

--- a/docs/src/models/ca-with-production.md
+++ b/docs/src/models/ca-with-production.md
@@ -87,7 +87,7 @@ CarboKitten.Models.CAP
 
 ``` {.julia file=src/Models/CAP.jl}
 @compose module CAP
-@mixin Tag, Diagnostics, Output, CAProduction, InitialSediment
+@mixin Tag, Diagnostics, Output, CAProduction
 
 using ..Common
 using ..CAProduction: production
@@ -109,15 +109,12 @@ function initial_state(input::Input)
         step=0, sediment_height=sediment_height,
         ca=ca_state.ca, ca_priority=ca_state.ca_priority)
 
-    InitialSediment.push_initial_sediment!(input, state)
     return state
 end
 
 function initial_frame(input::Input)
-    dep = stack(InitialSediment.initial_sediment(input.box, f) for f in input.facies; dims=1)
-    return Frame(production=zeros(Sediment,size(dep)), 
-                  disintegration=zeros(Sediment,size(dep)),
-                  deposition=dep)
+    return Frame(production=zeros(Sediment,n_facies(input), input.box.grid_size...), 
+                  deposition=zeros(Sediment,n_facies(input), input.box.grid_size...))
 end
 
 function step!(input::Input)

--- a/docs/src/models/ca-with-production.md
+++ b/docs/src/models/ca-with-production.md
@@ -148,3 +148,64 @@ function write_header(input::AbstractInput, output::AbstractOutput)
 end
 end
 ```
+
+## Tests
+
+Checks that the CAP model type runs without error and returns a result with the expected dimensions.
+
+``` {.julia file=test/Models/CAPSpec.jl}
+module CAPSpec
+
+using Test
+using Unitful
+
+using CarboKitten
+using CarboKitten.Models: CAP
+
+    const FACIES = [
+	    CAP.Facies(
+        viability_range = (4, 10),
+        activation_range = (6, 10),
+        production=BenthicProduction(
+            maximum_growth_rate = 500u"m/Myr",
+            extinction_coefficient = 0.8u"m^-1",
+            saturation_intensity = 60u"W/m^2")
+        ),
+	    CAP.Facies(
+        viability_range = (4, 10),
+        activation_range = (6, 10),
+        production=BenthicProduction(
+            maximum_growth_rate = 400u"m/Myr",
+            extinction_coefficient = 0.1u"m^-1",
+            saturation_intensity = 60u"W/m^2")
+        ),
+	    CAP.Facies(
+        viability_range = (4, 10),
+        activation_range = (6, 10),
+        production=BenthicProduction(
+            maximum_growth_rate = 100u"m/Myr",
+            extinction_coefficient = 0.005u"m^-1",
+            saturation_intensity = 60u"W/m^2")
+        )]
+
+    const INPUT = CAP.Input(
+		tag = "cap_test",
+		box = Box{Coast}(grid_size=(1, 1), phys_scale=150.0u"m"),
+		time = TimeProperties(
+			Δt = 200.0u"yr",
+			steps = 10),
+        output = Dict(
+            :full => OutputSpec(write_interval = 1)),
+		initial_topography = (x, y) -> - x / 300.0,
+		insolation = 400.0u"W/m^2",
+		facies = FACIES)
+
+    const OUT = run_model(Model{CAP}, INPUT, MemoryOutput(INPUT))
+
+    @testset "Models/CAP" begin
+        @test all(size(OUT.data_volumes[:full].sediment_thickness) .== (1,1,11))
+    end
+
+end
+
+```

--- a/examples/model/bs92/multi-facies-run.jl
+++ b/examples/model/bs92/multi-facies-run.jl
@@ -6,17 +6,20 @@ using CarboKitten
 
 const FACIES = [
     BS92.Facies(
-         maximum_growth_rate=500u"m/Myr"/4,
-         extinction_coefficient=0.8u"m^-1",
-         saturation_intensity=60u"W/m^2"),
+        production=BenthicProduction(
+            maximum_growth_rate=500u"m/Myr"/4,
+            extinction_coefficient=0.8u"m^-1",
+            saturation_intensity=60u"W/m^2")),
     BS92.Facies(
-         maximum_growth_rate=400u"m/Myr"/4,
-         extinction_coefficient=0.1u"m^-1",
-         saturation_intensity=60u"W/m^2"),
+        production=BenthicProduction(
+            maximum_growth_rate=400u"m/Myr"/4,
+            extinction_coefficient=0.1u"m^-1",
+            saturation_intensity=60u"W/m^2")),
     BS92.Facies(
-         maximum_growth_rate=100u"m/Myr"/4,
-         extinction_coefficient=0.005u"m^-1",
-         saturation_intensity=60u"W/m^2")]
+        production=BenthicProduction(
+            maximum_growth_rate=100u"m/Myr"/4,
+            extinction_coefficient=0.005u"m^-1",
+            saturation_intensity=60u"W/m^2"))]
 
 const INPUT = BS92.Input(
     tag = "example model BS92",

--- a/examples/model/bs92/run.jl
+++ b/examples/model/bs92/run.jl
@@ -27,9 +27,10 @@ const INPUT = BS92.Input(
     subsidence_rate = 0.0u"m/yr",
     insolation = 400.0u"W/m^2",
     facies = [BS92.Facies(
-      maximum_growth_rate = 0.005u"m/yr",
-      saturation_intensity = 50.0u"W/m^2",
-      extinction_coefficient = 0.05u"m^-1"
+      production=BenthicProduction(
+        maximum_growth_rate = 0.005u"m/yr",
+        saturation_intensity = 50.0u"W/m^2",
+        extinction_coefficient = 0.05u"m^-1")
     )])
 
 function main()

--- a/examples/model/cap/run.jl
+++ b/examples/model/cap/run.jl
@@ -11,23 +11,29 @@ const FACIES = [
 	    CAP.Facies(
         viability_range = (4, 10),
         activation_range = (6, 10),
-        maximum_growth_rate = 500u"m/Myr",
-        extinction_coefficient = 0.8u"m^-1",
-        saturation_intensity = 60u"W/m^2"),
+        production=BenthicProduction(
+            maximum_growth_rate = 500u"m/Myr",
+            extinction_coefficient = 0.8u"m^-1",
+            saturation_intensity = 60u"W/m^2"
+        )),
 
 	    CAP.Facies(
         viability_range = (4, 10),
         activation_range = (6, 10),
-        maximum_growth_rate = 400u"m/Myr",
-        extinction_coefficient = 0.1u"m^-1",
-        saturation_intensity = 60u"W/m^2"),
+        production=BenthicProduction(
+            maximum_growth_rate = 400u"m/Myr",
+            extinction_coefficient = 0.1u"m^-1",
+            saturation_intensity = 60u"W/m^2"
+        )),
 
 	    CAP.Facies(
         viability_range = (4, 10),
         activation_range = (6, 10),
-        maximum_growth_rate = 100u"m/Myr",
-        extinction_coefficient = 0.005u"m^-1",
-        saturation_intensity = 60u"W/m^2")
+        production=BenthicProduction(
+            maximum_growth_rate = 100u"m/Myr",
+            extinction_coefficient = 0.005u"m^-1",
+            saturation_intensity = 60u"W/m^2"
+        ))
 	]
 
 	const INPUT = CAP.Input(

--- a/src/Models/CAP.jl
+++ b/src/Models/CAP.jl
@@ -1,6 +1,6 @@
 # ~/~ begin <<docs/src/models/ca-with-production.md#src/Models/CAP.jl>>[init]
 @compose module CAP
-@mixin Tag, Diagnostics, Output, CAProduction, InitialSediment
+@mixin Tag, Diagnostics, Output, CAProduction
 
 using ..Common
 using ..CAProduction: production
@@ -22,15 +22,12 @@ function initial_state(input::Input)
         step=0, sediment_height=sediment_height,
         ca=ca_state.ca, ca_priority=ca_state.ca_priority)
 
-    InitialSediment.push_initial_sediment!(input, state)
     return state
 end
 
 function initial_frame(input::Input)
-    dep = stack(InitialSediment.initial_sediment(input.box, f) for f in input.facies; dims=1)
-    return Frame(production=zeros(Sediment,size(dep)), 
-                  disintegration=zeros(Sediment,size(dep)),
-                  deposition=dep)
+    return Frame(production=zeros(Sediment,n_facies(input), input.box.grid_size...), 
+                  deposition=zeros(Sediment,n_facies(input), input.box.grid_size...))
 end
 
 function step!(input::Input)

--- a/test/Models/CAPSpec.jl
+++ b/test/Models/CAPSpec.jl
@@ -1,0 +1,56 @@
+# ~/~ begin <<docs/src/models/ca-with-production.md#test/Models/CAPSpec.jl>>[init]
+module CAPSpec
+
+using Test
+using Unitful
+
+using CarboKitten
+using CarboKitten.Models: CAP
+
+    const FACIES = [
+	    CAP.Facies(
+        viability_range = (4, 10),
+        activation_range = (6, 10),
+        production=BenthicProduction(
+            maximum_growth_rate = 500u"m/Myr",
+            extinction_coefficient = 0.8u"m^-1",
+            saturation_intensity = 60u"W/m^2")
+        ),
+	    CAP.Facies(
+        viability_range = (4, 10),
+        activation_range = (6, 10),
+        production=BenthicProduction(
+            maximum_growth_rate = 400u"m/Myr",
+            extinction_coefficient = 0.1u"m^-1",
+            saturation_intensity = 60u"W/m^2")
+        ),
+	    CAP.Facies(
+        viability_range = (4, 10),
+        activation_range = (6, 10),
+        production=BenthicProduction(
+            maximum_growth_rate = 100u"m/Myr",
+            extinction_coefficient = 0.005u"m^-1",
+            saturation_intensity = 60u"W/m^2")
+        )]
+
+    const INPUT = CAP.Input(
+		tag = "cap_test",
+		box = Box{Coast}(grid_size=(1, 1), phys_scale=150.0u"m"),
+		time = TimeProperties(
+			Δt = 200.0u"yr",
+			steps = 10),
+        output = Dict(
+            :full => OutputSpec(write_interval = 1)),
+		initial_topography = (x, y) -> - x / 300.0,
+		insolation = 400.0u"W/m^2",
+		facies = FACIES)
+
+    const OUT = run_model(Model{CAP}, INPUT, MemoryOutput(INPUT))
+
+    @testset "Models/CAP" begin
+        @test all(size(OUT.data_volumes[:full].sediment_thickness) .== (1,1,11))
+    end
+
+end
+
+# ~/~ end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,4 +53,6 @@ TEST_PATH = mktempdir()
     include("ExportSpec.jl")
     include("Output/DataSpec.jl")
     include("Output/H5WriterSpec.jl")
+
+    include("Models/CAPSpec.jl")
 end


### PR DESCRIPTION
- Fixes #246 by removing `InitialSediment` from the `CAP` module mixins and replacing the `initial_frame` function with an implementation that writes a zero frame.
- Updates the examples for `CAP` and `BS92` models to use the new `BethicProduction` API
- Adds a test to check that the `CAP` model runs without error

@jhidding I couldn't find a way to just test that the model didn't throw an error, so it currently just checks that the output from the model is the expected size, since the test will error if there's an issue with the model.  Let me know if you can see a nicer way of doing this.